### PR TITLE
Add a preliminary implementation of metamorphic search

### DIFF
--- a/chrysalis/_internal/_controller.py
+++ b/chrysalis/_internal/_controller.py
@@ -1,5 +1,34 @@
-_KNOWLEDGE_BASE: list[str] = []
+from collections.abc import Callable
+
+from chrysalis._internal._relation import KnowledgeBase
+
+_CURRENT_KNOWLEDGE_BASE: KnowledgeBase | None = None
+"""
+The current knowledge space for the module.
+
+It is possible to "hack" the module to create a single source of truth knowledge base.
+This allows repeated calls to `register` to add relations the same knowledge base
+and for the knowledge base to be reset. It is important that this global variable start
+uninitialized so that its generic can be specified at run time.
+"""
 
 
-def register(s: str) -> None:
-    _KNOWLEDGE_BASE.append(s)
+def new_knowledge_base() -> None:
+    """Initialize a new knowledge base for the module."""
+    global _CURRENT_KNOWLEDGE_BASE  # NOQA: PLW0603
+    _CURRENT_KNOWLEDGE_BASE = KnowledgeBase()
+
+
+def register[T](
+    transformation: Callable[[T], T],
+    invariant: Callable[[T, T], bool],
+) -> None:
+    """Register a metamorphic relation into the current knowledge base."""
+    global _CURRENT_KNOWLEDGE_BASE  # NOQA: PLW0603
+    if _CURRENT_KNOWLEDGE_BASE is None:
+        _CURRENT_KNOWLEDGE_BASE = KnowledgeBase()
+
+    _CURRENT_KNOWLEDGE_BASE.register(
+        transformation=transformation,
+        invariant=invariant,
+    )

--- a/chrysalis/_internal/_controller_test.py
+++ b/chrysalis/_internal/_controller_test.py
@@ -1,8 +1,65 @@
 from chrysalis._internal import _controller as controller
 
 
-def test_register_string() -> None:
-    controller.register("hello")
-    controller.register("world")
+def identity(x: int) -> int:
+    return x
 
-    assert " ".join(controller._KNOWLEDGE_BASE) == "hello world"
+
+def inverse(x: int) -> int:
+    return -1 * x
+
+
+def equals(x: int, y: int) -> bool:
+    return x == y
+
+
+def not_equals(x: int, y: int) -> bool:
+    return x != y
+
+
+def is_same_sign(x: int, y: int) -> bool:
+    return x >= 0 and y >= 0 or x <= 0 and y <= 0
+
+
+def test_single_register() -> None:
+    controller.new_knowledge_base()
+    controller.register(
+        transformation=identity,
+        invariant=equals,
+    )
+
+    knowledge_base = controller._CURRENT_KNOWLEDGE_BASE
+
+    assert knowledge_base is not None
+    assert len(knowledge_base.relations) == 1
+    assert knowledge_base.relations[0].name == "identity"
+
+
+def test_multiple_register() -> None:
+    controller.new_knowledge_base()
+    controller.register(
+        transformation=identity,
+        invariant=equals,
+    )
+    controller.register(
+        transformation=identity,
+        invariant=is_same_sign,
+    )
+    controller.register(
+        transformation=inverse,
+        invariant=not_equals,
+    )
+
+    knowledge_base = controller._CURRENT_KNOWLEDGE_BASE
+
+    assert knowledge_base is not None
+    assert len(knowledge_base.relations) == 2
+    assert {relation.name for relation in knowledge_base.relations} == {
+        "identity",
+        "inverse",
+    }
+    assert set(knowledge_base._relations["identity"].invariants) == {
+        equals,
+        is_same_sign,
+    }
+    assert knowledge_base._relations["inverse"].invariants == [not_equals]

--- a/chrysalis/_internal/_relation.py
+++ b/chrysalis/_internal/_relation.py
@@ -1,0 +1,74 @@
+from collections.abc import Callable
+
+_LAMBDA_FUNCTION_NAME = "<lambda>"
+
+
+class Relation[T, R]:
+    """
+    A relationship between input change and output change.
+
+    Metamorphic relations are the fundamental building blocks of metamorphic testing.
+    Each metamorphic relation consists of a transformation and invariants. The
+    transformation is a function that transforms the input data. An invariant is a
+    conditional between the outputs of execution on the base input and transformed
+    input.
+    """
+
+    def __init__(
+        self,
+        transformation: Callable[[T], T],
+    ):
+        self._transformation = transformation
+        self._invariants: set[Callable[[R, R], bool]] = set()
+
+    def add_invariant(self, invariant: Callable[[R, R], bool]) -> None:
+        """Add an invariant to a transformation to create a new relation pair."""
+        self._invariants.add(invariant)
+
+    def apply_transform(self, data: T) -> T:
+        """Apply a relation's transformation."""
+        return self._transformation(data)
+
+    @property
+    def name(self) -> str:
+        return self._transformation.__name__
+
+    @property
+    def invariants(self) -> list[Callable[[R, R], bool]]:
+        return list(self._invariants)
+
+
+class KnowledgeBase[T, R]:
+    """
+    A collection of metamorphic relations.
+
+    Relations are registered in (transformation, invariant) pairs. Under the hood, a
+    relation stores single transformation and a list of invariants.
+
+    Is it important to note that lambda functions cannot be used for transformations or
+    invariants.
+    """
+
+    def __init__(self) -> None:
+        self._relations: dict[str, Relation[T, R]] = {}
+
+    def register(
+        self,
+        transformation: Callable[[T], T],
+        invariant: Callable[[R, R], bool],
+    ):
+        """Register a relation into the knowledge base, ensuring the name is unique."""
+        transform_name = transformation.__name__
+        if _LAMBDA_FUNCTION_NAME in {transform_name, invariant.__name__}:
+            raise ValueError(
+                "Lambda functions cannot be used as transformation or invariants."
+            )
+
+        if transform_name not in self._relations:
+            self._relations[transform_name] = Relation[T, R](transformation)
+        self._relations[transform_name].add_invariant(invariant)
+
+    @property
+    def relations(self) -> list[Relation[T, R]]:
+        """Return a list of all registered relations."""
+        return list(self._relations.values())

--- a/chrysalis/_internal/_relation_test.py
+++ b/chrysalis/_internal/_relation_test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from chrysalis._internal._relation import KnowledgeBase
+
+
+def identity(x: int) -> int:
+    return x
+
+
+def equals(x: int, y: int) -> bool:
+    return x == y
+
+
+def test_create_relation() -> None:
+    knowledge_base = KnowledgeBase[int, int]()
+    knowledge_base.register(
+        transformation=identity,
+        invariant=equals,
+    )
+
+    relation = knowledge_base.relations[0]
+    assert relation.name == "identity"
+    assert relation.invariants[0].__name__ == "equals"
+
+
+def test_create_relation_lambda() -> None:
+    knowledge_base = KnowledgeBase[int, int]()
+    with pytest.raises(
+        ValueError,
+        match="Lambda functions cannot be used as transformation or invariants.",
+    ):
+        knowledge_base.register(
+            transformation=lambda x: x,
+            invariant=lambda x, y: x == y,
+        )

--- a/chrysalis/_internal/_search.py
+++ b/chrysalis/_internal/_search.py
@@ -1,0 +1,41 @@
+import random
+from enum import Enum
+
+from chrysalis._internal._relation import KnowledgeBase, Relation
+
+
+class SearchStrategy(Enum):
+    """Possible search strategies when creating metamorphic relation chains."""
+
+    RANDOM = 1
+    EXHAUSTIVE = 2
+    DYNAMIC = 3
+
+
+class SearchSpace:
+    """A handle to interact with the search space for a knowledge base."""
+
+    def __init__(
+        self,
+        knowledge_base: KnowledgeBase,
+        strategy: SearchStrategy = SearchStrategy.RANDOM,
+        num_links: int = 10,
+    ):
+        self._knowledge_base = knowledge_base
+        self._strategy = strategy
+        self._num_links = num_links
+
+    def generate_chains(self, num_tests: int) -> list[list[Relation]]:
+        """Generate metamorphic chains based on search strategy."""
+        match self._strategy:
+            case SearchStrategy.RANDOM:
+                orderings = [
+                    random.choices(self._knowledge_base.relations, k=self._num_links)
+                    for _ in range(num_tests)
+                ]
+            case SearchStrategy.EXHAUSTIVE:
+                raise NotImplementedError
+            case SearchStrategy.DYNAMIC:
+                raise NotImplementedError
+
+        return orderings

--- a/chrysalis/_internal/_search_test.py
+++ b/chrysalis/_internal/_search_test.py
@@ -1,0 +1,50 @@
+from chrysalis._internal._relation import KnowledgeBase
+from chrysalis._internal._search import SearchSpace
+
+
+def identity(x: int) -> int:
+    return x
+
+
+def double_negative(x: int) -> int:
+    return -1 * -1 * x
+
+
+def inverse(x: int) -> int:
+    return -1 * x
+
+
+def equals(x: int, y: int) -> bool:
+    return x == y
+
+
+def not_equals(x: int, y: int) -> bool:
+    return x != y
+
+
+def test_metamorphic_search_random() -> None:
+    knowledge_base = KnowledgeBase[int, int]()
+
+    knowledge_base.register(
+        transformation=identity,
+        invariant=equals,
+    )
+    knowledge_base.register(
+        transformation=inverse,
+        invariant=not_equals,
+    )
+    knowledge_base.register(
+        transformation=double_negative,
+        invariant=equals,
+    )
+
+    search_space = SearchSpace(knowledge_base=knowledge_base)
+    relation_chains = search_space.generate_chains(5)
+    assert len(relation_chains) == 5
+    assert all(len(relation_chain) == 10 for relation_chain in relation_chains)
+    assert all(
+        {relation.name for relation in relation_chain}.issubset(
+            {"identity", "double_negative", "inverse"}
+        )
+        for relation_chain in relation_chains
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "chrysalis"
 dynamic = ["version"]
 description = 'A metamorphic testing framework for Python'
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = "MIT"
 keywords = []
 authors = [
@@ -17,14 +17,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
+  "Programming Language :: Python :: 3.13",
 ]
-dependencies = []
+dependencies = ["pytest"]
 
 [tool.hatch.version]
 path = "chrysalis/__about__.py"
@@ -37,8 +33,20 @@ extra-dependencies = ["mypy>=1.0.0"]
 [tool.hatch.envs.mypy.scripts]
 check = ["mypy --install-types --non-interactive {args:chrysalis tests}"]
 
+[tool.ruff]
+line-length = 88
+
 [tool.ruff.lint]
-ignore = ["T201", "PLC0414", "S101", "SLF001"]
+ignore = [
+  "T201",
+  "PLC0414",
+  "S101",
+  "SLF001",
+  "S311",
+  "PLR2004",
+  "TRY003",
+  "EM101",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["chrysalis"]


### PR DESCRIPTION
Original logic for the preliminary search implementation was written on branch `v1-examples`.