### PR TITLE
Reconfigure hatch to glob the correct paths with using pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ ignore = ["T201", "PLC0414", "S101", "SLF001"]
 [tool.ruff.lint.isort]
 known-first-party = ["chrysalis"]
 
+[tool.hatch.envs.hatch-test.scripts]
+run = "pytest chrysalis {args}"
+run-cov = "coverage run -m pytest tests/*.py chrysalis {args}"
+cov-combine = "coverage combine"
+cov-report = "coverage report"
+
 [tool.coverage.run]
 source_pkgs = ["chrysalis", "tests"]
 branch = true


### PR DESCRIPTION
The commands to run pytest within a hatch environment are:
- `hatch test`
- `hatch test --coverage`

The paths globbed for testing files are `./test/*.py` and `./chryaslis/`. Any python file in the `/tests` folder will be run on by pytest. Pytest follows the default file format for discovering pytest files in the `./chrysalis/` folder.