### PR TITLE
 Add `run` function to chrysalis as entry point to initiate testing

### DIFF
--- a/chrysalis/__init__.py
+++ b/chrysalis/__init__.py
@@ -1,1 +1,6 @@
-from chrysalis._internal._controller import register as register
+from chrysalis._internal._controller import (
+    register as register,
+)
+from chrysalis._internal._controller import (
+    run as run,
+)

--- a/chrysalis/_internal/_controller.py
+++ b/chrysalis/_internal/_controller.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
 from chrysalis._internal._relation import KnowledgeBase
+from chrysalis._internal._search import SearchSpace, SearchStrategy
 
 _CURRENT_KNOWLEDGE_BASE: KnowledgeBase | None = None
 """
@@ -19,9 +20,9 @@ def new_knowledge_base() -> None:
     _CURRENT_KNOWLEDGE_BASE = KnowledgeBase()
 
 
-def register[T](
+def register[T, R](
     transformation: Callable[[T], T],
-    invariant: Callable[[T, T], bool],
+    invariant: Callable[[R, R], bool],
 ) -> None:
     """Register a metamorphic relation into the current knowledge base."""
     global _CURRENT_KNOWLEDGE_BASE  # NOQA: PLW0603
@@ -32,3 +33,41 @@ def register[T](
         transformation=transformation,
         invariant=invariant,
     )
+
+
+def run[T, R](
+    sut: Callable[[T], R],  # NOQA: ARG001
+    dataset: list[R],  # NOQA: ARG001
+    search_strategy: SearchStrategy = SearchStrategy.RANDOM,
+    chain_length: int = 10,
+    num_chains: int = 10,
+) -> None:
+    """
+    Run metamorphic testing on the SUT using previously registered relations.
+
+    Parameter
+    ---------
+    sut : Callable[[T], R]
+        The 'system under test' that is currenting being tested.
+    dataset : Callable[[T], R]
+        The input data to be transformed and used as input into the SUT.
+    search_strategy : SearchStrategy, optional
+        The search strategy to use when generating metamorphic relation chains. The
+        serach strategy defaults to `SearchStrategy.RANDDOM`.
+    chain_length : int, optional
+        The number of relations in each generated metamorphic relation chain. The chain
+        length defaults to 10.
+    num_chains : int, optional
+        The number of metamorphic chains to generate. The number of chains defaults to
+        10.
+    """
+    if _CURRENT_KNOWLEDGE_BASE is None:
+        raise RuntimeError(
+            "No metamorphic relations have been registered in the current session, exiting."
+        )
+    search_space = SearchSpace(
+        knowledge_base=_CURRENT_KNOWLEDGE_BASE,
+        strategy=search_strategy,
+        chain_length=chain_length,
+    )
+    search_space.generate_chains(num_chains=num_chains)

--- a/chrysalis/_internal/_search.py
+++ b/chrysalis/_internal/_search.py
@@ -19,19 +19,19 @@ class SearchSpace:
         self,
         knowledge_base: KnowledgeBase,
         strategy: SearchStrategy = SearchStrategy.RANDOM,
-        num_links: int = 10,
+        chain_length: int = 10,
     ):
         self._knowledge_base = knowledge_base
         self._strategy = strategy
-        self._num_links = num_links
+        self._chain_length = chain_length
 
-    def generate_chains(self, num_tests: int) -> list[list[Relation]]:
+    def generate_chains(self, num_chains: int) -> list[list[Relation]]:
         """Generate metamorphic chains based on search strategy."""
         match self._strategy:
             case SearchStrategy.RANDOM:
                 orderings = [
-                    random.choices(self._knowledge_base.relations, k=self._num_links)
-                    for _ in range(num_tests)
+                    random.choices(self._knowledge_base.relations, k=self._chain_length)
+                    for _ in range(num_chains)
                 ]
             case SearchStrategy.EXHAUSTIVE:
                 raise NotImplementedError


### PR DESCRIPTION
@NFJ1618 This should be the last bit of functionality you needed before you could get started on the example. The execution engine scheduled for work in purely internal. 