### PR TITLE
Build SQL infrastructure for recreating inputs after transformations

### DIFF
--- a/chrysalis/_internal/_controller_test.py
+++ b/chrysalis/_internal/_controller_test.py
@@ -17,7 +17,9 @@ def test_single_register() -> None:
 
     assert knowledge_base is not None
     assert len(knowledge_base.relations) == 1
-    assert knowledge_base.relations[0].transformation_name == "identity"
+    assert (
+        next(iter(knowledge_base.relations.values())).transformation_name == "identity"
+    )
 
 
 def test_multiple_register() -> None:
@@ -39,12 +41,22 @@ def test_multiple_register() -> None:
 
     assert knowledge_base is not None
     assert len(knowledge_base.relations) == 2
-    assert {relation.transformation_name for relation in knowledge_base.relations} == {
+    assert {
+        relation.transformation_name for relation in knowledge_base.relations.values()
+    } == {
         "identity",
         "inverse",
     }
-    assert set(knowledge_base._relations["identity"].invariants) == {
+    assert set(
+        knowledge_base._relations[
+            knowledge_base.transformation_ids["identity"]
+        ].invariants.values()
+    ) == {
         invariants.equals,
         invariants.is_same_sign,
     }
-    assert knowledge_base._relations["inverse"].invariants == [invariants.not_equals]
+    assert set(
+        knowledge_base._relations[
+            knowledge_base.transformation_ids["inverse"]
+        ].invariants.values()
+    ) == {invariants.not_equals}

--- a/chrysalis/_internal/_relation.py
+++ b/chrysalis/_internal/_relation.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+from chrysalis._internal import _tables as tables
+
 _LAMBDA_FUNCTION_NAME = "<lambda>"
 
 
@@ -17,25 +19,42 @@ class Relation[T, R]:
     def __init__(
         self,
         transformation: Callable[[T], T],
+        transformation_id: str,
     ):
         self._transformation = transformation
-        self._invariants: set[Callable[[R, R], bool]] = set()
+        self._transformation_id = transformation_id
+        self._invariants: dict[str, Callable[[R, R], bool]] = {}
 
-    def add_invariant(self, invariant: Callable[[R, R], bool]) -> None:
+    def add_invariant(
+        self,
+        invariant: Callable[[R, R], bool],
+        invariant_id: str,
+    ) -> None:
         """Add an invariant to a transformation to create a new relation pair."""
-        self._invariants.add(invariant)
+        self._invariants[invariant_id] = invariant
 
     def apply_transform(self, data: T) -> T:
         """Apply a relation's transformation."""
         return self._transformation(data)
 
     @property
+    def transformation_id(self) -> str:
+        return self._transformation_id
+
+    @property
     def transformation_name(self) -> str:
         return self._transformation.__name__
 
     @property
-    def invariants(self) -> list[Callable[[R, R], bool]]:
-        return list(self._invariants)
+    def invariants(self) -> dict[str, Callable[[R, R], bool]]:
+        return self._invariants
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"transformation={self._transformation.__name__}, "
+            f"invariants={[invariant.__name__ for invariant in self._invariants.values()]})"
+        )
 
 
 class KnowledgeBase[T, R]:
@@ -50,6 +69,8 @@ class KnowledgeBase[T, R]:
     """
 
     def __init__(self) -> None:
+        self._transformations: dict[str, str] = {}
+        self._invariants: dict[str, str] = {}
         self._relations: dict[str, Relation[T, R]] = {}
 
     def register(
@@ -58,17 +79,44 @@ class KnowledgeBase[T, R]:
         invariant: Callable[[R, R], bool],
     ):
         """Register a relation into the knowledge base, ensuring the name is unique."""
-        transform_name = transformation.__name__
-        if _LAMBDA_FUNCTION_NAME in {transform_name, invariant.__name__}:
+        transformation_name = transformation.__name__
+        invariant_name = invariant.__name__
+        if _LAMBDA_FUNCTION_NAME in {transformation_name, invariant_name}:
             raise ValueError(
                 "Lambda functions cannot be used as transformation or invariants."
             )
 
-        if transform_name not in self._relations:
-            self._relations[transform_name] = Relation[T, R](transformation)
-        self._relations[transform_name].add_invariant(invariant)
+        if transformation_name not in self._transformations:
+            self._transformations[transformation_name] = tables.generate_uuid()
+        if invariant_name not in self._invariants:
+            self._invariants[invariant_name] = tables.generate_uuid()
+        transformation_id = self._transformations[transformation_name]
+        invariant_id = self._invariants[invariant_name]
+
+        if transformation_id not in self._relations:
+            self._relations[transformation_id] = Relation[T, R](
+                transformation,
+                transformation_id,
+            )
+        self._relations[transformation_id].add_invariant(invariant, invariant_id)
 
     @property
-    def relations(self) -> list[Relation[T, R]]:
-        """Return a list of all registered relations."""
-        return list(self._relations.values())
+    def transformation_ids(self) -> dict[str, str]:
+        """Return mappings from transformation name to transformation id."""
+        return self._transformations
+
+    @property
+    def invariant_ids(self) -> dict[str, str]:
+        """Return mappings from invariant name to invariant id."""
+        return self._invariants
+
+    @property
+    def relations(self) -> dict[str, Relation[T, R]]:
+        """Return a mapping of all registered relations."""
+        return self._relations
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"relations={list(self._transformations.keys())}"
+        )

--- a/chrysalis/_internal/_relation_test.py
+++ b/chrysalis/_internal/_relation_test.py
@@ -14,9 +14,12 @@ def test_create_relation() -> None:
         invariant=invariants.equals,
     )
 
-    relation = knowledge_base.relations[0]
+    assert len(knowledge_base.relations) == 1
+    relation = next(iter(knowledge_base.relations.values()))
     assert relation.transformation_name == "identity"
-    assert relation.invariants[0].__name__ == "equals"
+    assert [invariant.__name__ for invariant in relation.invariants.values()] == [
+        "equals"
+    ]
 
 
 def test_create_relation_lambda() -> None:

--- a/chrysalis/_internal/_search.py
+++ b/chrysalis/_internal/_search.py
@@ -30,7 +30,10 @@ class SearchSpace:
         match self._strategy:
             case SearchStrategy.RANDOM:
                 orderings = [
-                    random.choices(self._knowledge_base.relations, k=self._chain_length)
+                    random.choices(
+                        list(self._knowledge_base.relations.values()),
+                        k=self._chain_length,
+                    )
                     for _ in range(num_chains)
                 ]
             case SearchStrategy.EXHAUSTIVE:

--- a/chrysalis/_internal/_tables.py
+++ b/chrysalis/_internal/_tables.py
@@ -1,0 +1,226 @@
+import sqlite3
+import uuid
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import duckdb
+
+from chrysalis._internal._relation import KnowledgeBase
+
+_CREATE_TRANSFORMATION_TABLE = """
+CREATE TABLE transformation (
+    id TEXT PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+);
+"""
+
+_CREATE_INVARIANT_TABLE = """
+CREATE TABLE invariant (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+"""
+
+_CREATE_RELATION_TABLE = """
+CREATE TABLE relation (
+    transformation TEXT NOT NULL,
+    invariant TEXT NOT NULL,
+
+    FOREIGN KEY (transformation) REFERENCES transformation(id),
+    FOREIGN KEY (invariant) REFERENCES invariant(id)
+);
+"""
+
+_CREATE_INPUT_DATA_TABLE = """
+CREATE TABLE input_data (
+    id TEXT PRIMARY KEY,
+    obj BLOB NOT NULL
+);
+"""
+
+_CREATE_APPLIED_TRANSFORMATION_TABLE = """
+CREATE TABLE applied_transformation (
+    id TEXT PRIMARY KEY,
+    transformation TEXT NOT NULL,
+    relation_chain_id TEXT,
+    link_index INT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (transformation) REFERENCES transformation(id)
+);
+"""
+
+_CREATE_FAILED_INVARIANT_TABLE = """
+CREATE TABLE failed_invariant (
+    id TEXT PRIMARY KEY,
+    invariant TEXT NOT NULL,
+    applied_transformation TEXT NOT NULL,
+    input_data TEXT NOT NULL,
+
+    FOREIGN KEY (invariant) REFERENCES invariant(id),
+    FOREIGN KEY (applied_transformation) REFERENCES applied_transformation(id),
+    FOREIGN KEY (input_data) REFERENCES input_data(id)
+);
+"""
+
+
+class TemporarySqlite3RelationConnection(TemporaryDirectory):
+    """
+    A temporary sqlite3 database designed to be used for transactional inserts.
+
+    During metamorphic testing, we want to record the order of which transformations are
+    applied and the result of each invariant tested in a relation chain. This data is
+    available after each step that is executed in the engine. By definition, this
+    pattern follows the transactional processing pattern and thus justifies using
+    sqlite3.
+
+    This database maintains two tables that are required to store the results of
+    execution of a relation chain. The first table is the `transformation` table which
+    records the order of which tranformations are applied to input data. The second
+    table `failed_invariant` represents the result of a individual invariant tested for
+    a given transformation that failed. It is important to note, it is possible that
+    multiple invariants apply to the same transformation and thus a single transformation
+    can have multiple invariants that fail.
+
+    Given this database design, it is not required to store the result of
+    transformations on the input data. Instead, the transformations can be reapplied to
+    the input data to acheive indiviudal instances of transformed data that is
+    requested. This dramatically reduces the amount of data that is required to be
+    stored.
+
+    Since this is a temporary sqlite3 connection, it is expected that all data will be
+    extracted before exiting the context manager.
+    """
+
+    def __init__(self, knowledge_base: KnowledgeBase):
+        self._knowledge_base = knowledge_base
+        super().__init__()
+
+    def __enter__(self, *args, **kwargs) -> tuple[sqlite3.Connection, Path]:
+        """
+        Create a database in the temporary directory created during initialization.
+
+        In addition to creating the database, configure the sqlite3 database rules and
+        create the relevant tables.
+        """
+        temp_dir = super().__enter__(*args, **kwargs)
+        # Arguably, this context manager should be based off `TemporaryFile` instead of
+        # `TemporaryDirectory`, but this design was chosen due to ease of
+        # implementation.
+        db_path = Path(temp_dir) / "chry.db"
+        conn = sqlite3.connect(db_path)
+
+        # Sqlite3 doesn't enfore foreign key existance by default.
+        conn.execute("PRAGMA foreign_keys = ON")
+
+        conn.execute(_CREATE_TRANSFORMATION_TABLE)
+        conn.execute(_CREATE_INVARIANT_TABLE)
+        conn.execute(_CREATE_RELATION_TABLE)
+        conn.execute(_CREATE_INPUT_DATA_TABLE)
+        conn.execute(_CREATE_APPLIED_TRANSFORMATION_TABLE)
+        conn.execute(_CREATE_FAILED_INVARIANT_TABLE)
+
+        for (
+            transformation_name,
+            transformation_id,
+        ) in self._knowledge_base.transformation_ids.items():
+            conn.execute(
+                "INSERT INTO transformation (id, name) VALUES (?, ?);",
+                (transformation_id, transformation_name),
+            )
+
+        for (
+            invariant_name,
+            invariant_id,
+        ) in self._knowledge_base.invariant_ids.items():
+            conn.execute(
+                "INSERT INTO invariant (id, name) VALUES (?, ?);",
+                (invariant_id, invariant_name),
+            )
+
+        for relation in self._knowledge_base.relations.values():
+            for invariant_id in relation.invariants:
+                conn.execute(
+                    "INSERT INTO relation (transformation, invariant) VALUES (?, ?);",
+                    (relation.transformation_id, invariant_id),
+                )
+
+        return conn, db_path
+
+
+def sqlite_to_duckdb(sqlite_db: Path) -> duckdb.DuckDBPyConnection:
+    """
+    Convert a chrysalis sqlite3 database into a duckdb database.
+
+    Converting a sqilte3 database to a duckdb database is non-trivial due to the
+    conversion needing to be done one table at a time. Additionally, some tables, such
+    as the `applied_transformation` table require additional care as self-referential
+    foreign key constraints can become problematic.
+    """
+    duckdb_conn = duckdb.connect()
+
+    # Sqlite needs to be installed within duckdb before `sqlite_scan` can be used.
+    duckdb_conn.execute("INSTALL sqlite;")
+
+    # The schema of the tables needs to be specified before records are inserted. If
+    # the schema is inferred from sqlite, it may be wrong.
+    duckdb_conn.execute(_CREATE_TRANSFORMATION_TABLE)
+    duckdb_conn.execute(_CREATE_INVARIANT_TABLE)
+    duckdb_conn.execute(_CREATE_RELATION_TABLE)
+    duckdb_conn.execute(_CREATE_INPUT_DATA_TABLE)
+    duckdb_conn.execute(_CREATE_APPLIED_TRANSFORMATION_TABLE)
+    duckdb_conn.execute(_CREATE_FAILED_INVARIANT_TABLE)
+
+    duckdb_conn.execute(
+        """
+INSERT INTO transformation
+SELECT * FROM sqlite_scan(?, ?);
+                """,
+        (str(sqlite_db), "transformation"),
+    )
+
+    duckdb_conn.execute(
+        """
+INSERT INTO invariant
+SELECT * FROM sqlite_scan(?, ?);
+                """,
+        (str(sqlite_db), "invariant"),
+    )
+
+    duckdb_conn.execute(
+        """
+INSERT INTO relation
+SELECT * FROM sqlite_scan(?, ?);
+                """,
+        (str(sqlite_db), "relation"),
+    )
+
+    duckdb_conn.execute(
+        """
+INSERT INTO input_data
+SELECT * FROM sqlite_scan(?, ?);
+                """,
+        (str(sqlite_db), "input_data"),
+    )
+
+    duckdb_conn.execute(
+        """
+INSERT INTO applied_transformation
+SELECT * FROM sqlite_scan(?, ?);
+                """,
+        (str(sqlite_db), "applied_transformation"),
+    )
+
+    duckdb_conn.execute(
+        """
+INSERT INTO failed_invariant
+SELECT * FROM sqlite_scan(?, ?);
+                """,
+        (str(sqlite_db), "failed_invariant"),
+    )
+    return duckdb_conn
+
+
+def generate_uuid() -> str:
+    """Generate a 16 byte random uuid using the UUID4 specification."""
+    return uuid.uuid4().hex

--- a/chrysalis/_internal/_tables_test.py
+++ b/chrysalis/_internal/_tables_test.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from chrysalis._internal import _tables as tables
+from chrysalis._internal._relation import KnowledgeBase
+
+
+def test_temporary_sqlite_db_deletes_success(
+    mock_knowledge_base: KnowledgeBase,
+) -> None:
+    with tables.TemporarySqlite3RelationConnection(
+        knowledge_base=mock_knowledge_base
+    ) as (_, db_path):
+        pass
+    assert not db_path.exists()
+
+
+def test_temporary_sqlite_db_deletes_error(mock_knowledge_base: KnowledgeBase) -> None:
+    p: Path | None = None
+    try:
+        with tables.TemporarySqlite3RelationConnection(
+            knowledge_base=mock_knowledge_base
+        ) as (_, db_path):
+            p = db_path
+            raise RuntimeError(  # NOQA: TRY301
+                "This runtime error is designed to ensure the sqlite database is deleted even if an error occurs during execution."
+            )
+    except Exception:  # NOQA: BLE001
+        assert p is not None
+        assert not p.exists()
+
+
+def test_temporary_sqlite_db_fields(
+    mock_knowledge_base: KnowledgeBase,
+) -> None:
+    with tables.TemporarySqlite3RelationConnection(
+        knowledge_base=mock_knowledge_base
+    ) as (conn, _):
+        transformations_values = conn.execute(
+            "SELECT name, id FROM transformation;"
+        ).fetchall()
+        invariants_values = conn.execute("SELECT name, id FROM invariant;").fetchall()
+
+        assert {
+            transformation_values[0] for transformation_values in transformations_values
+        } == {
+            "identity",
+            "inverse",
+            "add_1_to_expression",
+            "subtract_1_from_expression",
+        }
+        assert {invariant_values[0] for invariant_values in invariants_values} == {
+            "equals",
+            "not_same_sign",
+            "greater_than",
+            "less_than",
+        }
+        assert conn.execute("SELECT COUNT(*) FROM relation;").fetchone()[0] == 5
+
+        for transformation_name, transformation_id in transformations_values:
+            assert transformation_name in mock_knowledge_base.transformation_ids
+            assert (
+                mock_knowledge_base.transformation_ids[transformation_name]
+                == transformation_id
+            )
+
+            relation = mock_knowledge_base.relations[transformation_id]
+            assert relation.transformation_name == transformation_name
+            assert relation.transformation_id == transformation_id
+
+            for invariant_id, invariant in relation.invariants.items():
+                invariant_name = invariant.__name__
+                assert invariant_name in mock_knowledge_base.invariant_ids
+                assert mock_knowledge_base.invariant_ids[invariant_name] == invariant_id
+
+        for invariant_name, invariant_id in invariants_values:
+            assert invariant_name in mock_knowledge_base.invariant_ids
+            assert mock_knowledge_base.invariant_ids[invariant_name] == invariant_id


### PR DESCRIPTION
A main goal of Chrysalis is to be able to interactively inspect tests performed during metamorphic testing. This requires that relation chains tested must be recorded. To save disk space, we can only save the starting input dataset. Later, when we want to retrieve input data after performing transformations, we can re-apply the transformations in order to recreate that input data. This only works when the transformations are deterministic.

While there had been some work already done to record tested relation chains into the SQL database, this work was incomplete and new tables were needed to be created to normalize the database.
