### PR TITLE
Refactor search system to use generator pattern

### DIFF
--- a/chrysalis/_internal/_controller.py
+++ b/chrysalis/_internal/_controller.py
@@ -18,7 +18,7 @@ uninitialized so that its generic can be specified at run time.
 """
 
 
-def new_knowledge_base() -> None:
+def reset_knowledge_base() -> None:
     """Initialize a new knowledge base for the module."""
     global _CURRENT_KNOWLEDGE_BASE  # NOQA: PLW0603
     _CURRENT_KNOWLEDGE_BASE = KnowledgeBase()
@@ -46,7 +46,7 @@ def run[T, R](
     chain_length: int = 10,
     num_chains: int = 10,
     num_processes: int = 1,
-) -> duckdb.DuckDBPyConnection | None:
+) -> duckdb.DuckDBPyConnection:
     """
     Run metamorphic testing on the SUT using previously registered relations.
 
@@ -81,18 +81,20 @@ def run[T, R](
         search_space = SearchSpace(
             knowledge_base=_CURRENT_KNOWLEDGE_BASE,
             strategy=search_strategy,
-            chain_length=chain_length,
         )
-        relation_chains = search_space.generate_chains(num_chains=num_chains)
 
         engine = Engine(
             sut=sut,
-            sqlite_conn=conn,
             input_data=input_data,
-            sqlite_db=db_path,
             num_processes=num_processes,
+            search_space=search_space,
+            sqlite_conn=conn,
+            sqlite_db=db_path,
         )
-        engine.execute(relation_chains)
+        engine.execute(
+            chain_length=chain_length,
+            num_chains=num_chains,
+        )
 
         duckdb_conn = engine.results_to_duckdb()
         conn.close()

--- a/chrysalis/_internal/_controller_test.py
+++ b/chrysalis/_internal/_controller_test.py
@@ -7,7 +7,7 @@ from chrysalis._internal.conftest import (
 
 
 def test_single_register() -> None:
-    controller.new_knowledge_base()
+    controller.reset_knowledge_base()
     controller.register(
         transformation=identity,
         invariant=invariants.equals,
@@ -23,7 +23,7 @@ def test_single_register() -> None:
 
 
 def test_multiple_register() -> None:
-    controller.new_knowledge_base()
+    controller.reset_knowledge_base()
     controller.register(
         transformation=identity,
         invariant=invariants.equals,

--- a/chrysalis/_internal/_search_test.py
+++ b/chrysalis/_internal/_search_test.py
@@ -1,8 +1,9 @@
 import ast
+import random
 
 from chrysalis._internal import _invariants as invariants
 from chrysalis._internal._relation import KnowledgeBase
-from chrysalis._internal._search import SearchSpace
+from chrysalis._internal._search import SearchSpace, SearchStrategy
 from chrysalis._internal.conftest import (
     identity,
     inverse,
@@ -21,13 +22,16 @@ def test_metamorphic_search_random() -> None:
         invariant=invariants.not_equals,
     )
 
-    search_space = SearchSpace(knowledge_base=knowledge_base)
-    relation_chains = search_space.generate_chains(5)
-    assert len(relation_chains) == 5
-    assert all(len(relation_chain) == 10 for relation_chain in relation_chains)
-    assert all(
-        {relation.transformation_name for relation in relation_chain}.issubset(
-            {"identity", "inverse"}
-        )
-        for relation_chain in relation_chains
+    search_space = SearchSpace(
+        knowledge_base=knowledge_base, strategy=SearchStrategy.RANDOM
     )
+
+    random.seed(0)
+    generator = search_space.create_generator()
+    relation_chain = [next(generator) for _ in range(10)]
+
+    assert len(relation_chain) == 10
+    assert set([relation.transformation_name for relation in relation_chain]) == {
+        "identity",
+        "inverse",
+    }


### PR DESCRIPTION
Change pattern for SearchSpace to use generators

Replace static chain generation with `SearchGenerator` pattern
for more flexible metamorphic relation selection. Rename
`new_knowledge_base` to `reset_knowledge_base` for clarity.
