### PR TITLE
Add optional database persistence to `run` function

### DIFF
--- a/chrysalis/_internal/_controller.py
+++ b/chrysalis/_internal/_controller.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from pathlib import Path
 
 import duckdb
 
@@ -45,6 +46,7 @@ def run[T, R](
     search_strategy: SearchStrategy = SearchStrategy.RANDOM,
     chain_length: int = 10,
     num_chains: int = 10,
+    persistent_db_path: Path | None = None,
     num_processes: int = 1,
 ) -> duckdb.DuckDBPyConnection:
     """
@@ -66,6 +68,10 @@ def run[T, R](
     num_chains : int, optional
         The number of metamorphic chains to generate. The number of chains defaults to
         10.
+    persistent_db_path : Path, optional
+        The location to save the database file for the resultant duckdb connection. If
+        no value is specified, the duckdb connection is made in-memory and thus the
+        data in the connection is lost when the processes exits.
     num_processes: int, optional
         The number of processes to use when performing metamorphic testing.
     """
@@ -96,7 +102,7 @@ def run[T, R](
             num_chains=num_chains,
         )
 
-        duckdb_conn = engine.results_to_duckdb()
+        duckdb_conn = engine.results_to_duckdb(db_path=persistent_db_path)
         conn.close()
 
     return duckdb_conn

--- a/chrysalis/_internal/_engine.py
+++ b/chrysalis/_internal/_engine.py
@@ -202,7 +202,9 @@ VALUES (?, ?, ?, ?);
             )
         self._conn.commit()
 
-    def results_to_duckdb(self) -> duckdb.DuckDBPyConnection:
+    def results_to_duckdb(
+        self, db_path: Path | None = None
+    ) -> duckdb.DuckDBPyConnection:
         """
         Convert the sqlite3 database kept during execution into a duckdb database.
 
@@ -212,4 +214,4 @@ VALUES (?, ?, ?, ?);
         convert the database into a duckdb database due to duckdb's better performance
         on analytical queries and better data compression.
         """
-        return tables.sqlite_to_duckdb(self._sqlite_db)
+        return tables.sqlite_to_duckdb(self._sqlite_db, output_db_path=db_path)

--- a/chrysalis/_internal/_tables.py
+++ b/chrysalis/_internal/_tables.py
@@ -148,7 +148,10 @@ class TemporarySqlite3RelationConnection(TemporaryDirectory):
         return conn, db_path
 
 
-def sqlite_to_duckdb(sqlite_db: Path) -> duckdb.DuckDBPyConnection:
+def sqlite_to_duckdb(
+    sqlite_db: Path,
+    output_db_path: Path | None = None,
+) -> duckdb.DuckDBPyConnection:
     """
     Convert a chrysalis sqlite3 database into a duckdb database.
 
@@ -157,7 +160,10 @@ def sqlite_to_duckdb(sqlite_db: Path) -> duckdb.DuckDBPyConnection:
     as the `applied_transformation` table require additional care as self-referential
     foreign key constraints can become problematic.
     """
-    duckdb_conn = duckdb.connect()
+    if output_db_path is not None:
+        duckdb_conn = duckdb.connect(output_db_path)
+    else:
+        duckdb_conn = duckdb.connect()
 
     # Sqlite needs to be installed within duckdb before `sqlite_scan` can be used.
     duckdb_conn.execute("INSTALL sqlite;")


### PR DESCRIPTION
Add `persistent_db_path` parameter to the `run` function in `_controller.py` to allow saving DuckDB databases to disk. Update `results_to_duckdb` and `sqlite_to_duckdb` functions to support the optional path parameter for database persistence.
